### PR TITLE
Make SwiftUI Logic Also use RenderingError enum

### DIFF
--- a/Sources/SnapshotPreviewsCore/AppKitRenderingStrategy.swift
+++ b/Sources/SnapshotPreviewsCore/AppKitRenderingStrategy.swift
@@ -52,7 +52,7 @@ public class AppKitRenderingStrategy: RenderingStrategy {
         let image = vc?.view.snapshot()
         completion(
           SnapshotResult(
-            image: image != nil ? .success(image!) : .failure(SwiftUIRenderingError.renderingError),
+            image: image != nil ? .success(image!) : .failure(RenderingError.failedRendering(vc?.view.bounds.size ?? .zero)),
             precision: precision,
             accessibilityEnabled: accessibilityEnabled,
             accessibilityMarkers: nil,

--- a/Sources/SnapshotPreviewsCore/SwiftUIRenderingStrategy.swift
+++ b/Sources/SnapshotPreviewsCore/SwiftUIRenderingStrategy.swift
@@ -8,10 +8,6 @@
 import Foundation
 import SwiftUI
 
-enum SwiftUIRenderingError: Error {
-  case renderingError
-}
-
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, visionOS 1.0, *)
 public class SwiftUIRenderingStrategy: RenderingStrategy {
 
@@ -41,7 +37,7 @@ public class SwiftUIRenderingStrategy: RenderingStrategy {
     if let image {
       completion(SnapshotResult(image: .success(image), precision: wrappedView.precision, accessibilityEnabled: wrappedView.accessibilityEnabled, accessibilityMarkers: [], colorScheme: colorScheme, appStoreSnapshot: wrappedView.appStoreSnapshot))
     } else {
-      completion(SnapshotResult(image: .failure(SwiftUIRenderingError.renderingError), precision: wrappedView.precision, accessibilityEnabled: wrappedView.accessibilityEnabled, accessibilityMarkers: [], colorScheme: colorScheme, appStoreSnapshot: wrappedView.appStoreSnapshot))
+      completion(SnapshotResult(image: .failure(RenderingError.failedRendering(image?.size ?? .zero)), precision: wrappedView.precision, accessibilityEnabled: wrappedView.accessibilityEnabled, accessibilityMarkers: [], colorScheme: colorScheme, appStoreSnapshot: wrappedView.appStoreSnapshot))
     }
   }
 }

--- a/Sources/SnapshotPreviewsCore/SwiftUIRenderingStrategy.swift
+++ b/Sources/SnapshotPreviewsCore/SwiftUIRenderingStrategy.swift
@@ -37,7 +37,7 @@ public class SwiftUIRenderingStrategy: RenderingStrategy {
     if let image {
       completion(SnapshotResult(image: .success(image), precision: wrappedView.precision, accessibilityEnabled: wrappedView.accessibilityEnabled, accessibilityMarkers: [], colorScheme: colorScheme, appStoreSnapshot: wrappedView.appStoreSnapshot))
     } else {
-      completion(SnapshotResult(image: .failure(RenderingError.failedRendering(image?.size ?? .zero)), precision: wrappedView.precision, accessibilityEnabled: wrappedView.accessibilityEnabled, accessibilityMarkers: [], colorScheme: colorScheme, appStoreSnapshot: wrappedView.appStoreSnapshot))
+      completion(SnapshotResult(image: .failure(RenderingError.failedRendering(.zero)), precision: wrappedView.precision, accessibilityEnabled: wrappedView.accessibilityEnabled, accessibilityMarkers: [], colorScheme: colorScheme, appStoreSnapshot: wrappedView.appStoreSnapshot))
     }
   }
 }

--- a/Sources/SnapshotPreviewsCore/View+Snapshot.swift
+++ b/Sources/SnapshotPreviewsCore/View+Snapshot.swift
@@ -5,18 +5,20 @@
 //  Created by Noah Martin on 12/22/22.
 //
 
-#if canImport(UIKit) && !os(visionOS) && !os(watchOS) && !os(tvOS)
-import Foundation
-import SwiftUI
-import UIKit
-import AccessibilitySnapshotCore
-import SnapshotSharedModels
+import CoreFoundation
 
 public enum RenderingError: Error {
   case failedRendering(CGSize)
   case maxSize(CGSize)
   case expandingViewTimeout(CGSize)
 }
+
+#if canImport(UIKit) && !os(visionOS) && !os(watchOS) && !os(tvOS)
+import Foundation
+import SwiftUI
+import UIKit
+import AccessibilitySnapshotCore
+import SnapshotSharedModels
 
 extension AccessibilityMarker: AccessibilityMark {
   public var accessibilityShape: MarkerShape {


### PR DESCRIPTION
We had an issue where some mac previews were failing to render, and it was unclear why. We should have had the "zero width" situation handled, but it was only configured for UIKit rendering, not AppKit rendering.

I went ahead and made the AppKit/SwiftUI rendering use the same error enum type. Our backend/web should then parse this correctly