### PR TITLE
add orientation specific timeout handling

### DIFF
--- a/Sources/SnapshotPreviewsCore/UIKitRenderingStrategy.swift
+++ b/Sources/SnapshotPreviewsCore/UIKitRenderingStrategy.swift
@@ -63,8 +63,12 @@ public class UIKitRenderingStrategy: RenderingStrategy {
       completion: @escaping (SnapshotResult) -> Void
   ) {
       if let geometryUpdateError {
+        if (geometryUpdateError as NSError).userInfo["BSErrorCodeDescription"] as? String == "timeout" {
+            completion(SnapshotResult(image: .failure(RenderingError.orientationChangeTimeout), precision: nil, accessibilityEnabled: nil, accessibilityMarkers: nil, colorScheme: nil, appStoreSnapshot: nil))
+            return
+        }
         completion(SnapshotResult(image: .failure(geometryUpdateError), precision: nil, accessibilityEnabled: nil, accessibilityMarkers: nil, colorScheme: nil, appStoreSnapshot: nil))
-          return
+        return
       }
       guard attempts > 0 else {
           let timeoutError = NSError(domain: "OrientationChangeTimeout", code: 0, userInfo: [NSLocalizedDescriptionKey: "Orientation change timed out"])

--- a/Sources/SnapshotPreviewsCore/View+Snapshot.swift
+++ b/Sources/SnapshotPreviewsCore/View+Snapshot.swift
@@ -11,6 +11,7 @@ public enum RenderingError: Error {
   case failedRendering(CGSize)
   case maxSize(CGSize)
   case expandingViewTimeout(CGSize)
+  case orientationChangeTimeout
 }
 
 #if canImport(UIKit) && !os(visionOS) && !os(watchOS) && !os(tvOS)


### PR DESCRIPTION
Catch this error

```
Error Domain=BSActionErrorDomain Code=2 \"(null)\" UserInfo={BSErrorCodeDescription=timeout}
```

and treat it as a formatted `RenderingError`.

Worth noting that in situations where we saw this error, it occurred sporadically