### PR TITLE
Fixes for device builds on iOS 26

### DIFF
--- a/Sources/SnapshotPreviewsCore/ConformanceLookup.swift
+++ b/Sources/SnapshotPreviewsCore/ConformanceLookup.swift
@@ -86,7 +86,7 @@ public func getPreviewTypes() -> [LookupResult] {
   for i in 0..<images {
     let imageName = String(cString: _dyld_get_image_name(i))
     // System frameworks on the simulator are in Xcode.app/Contents/** (Although Xcode could be renamed like Xcode-beta.app so don't check for that specifically)
-    guard !imageName.contains(".simruntime") && !imageName.contains(".app/Contents/Developer") && !imageName.starts(with: "/usr/lib/") else {
+    guard !imageName.contains(".simruntime") && !imageName.contains(".app/Contents/Developer") && !imageName.starts(with: "/usr/lib/") && !imageName.starts(with: "/System/Library/") else {
       continue
     }
 


### PR DESCRIPTION
Fix for iOS 26 device builds, which has a system framework that contains a crashing preview