### PR TITLE
Better image path check

### DIFF
--- a/Sources/SnapshotPreviewsCore/ConformanceLookup.swift
+++ b/Sources/SnapshotPreviewsCore/ConformanceLookup.swift
@@ -85,8 +85,7 @@ public func getPreviewTypes() -> [LookupResult] {
   var types = [LookupResult]()
   for i in 0..<images {
     let imageName = String(cString: _dyld_get_image_name(i))
-    // System frameworks on the simulator are in Xcode.app/Contents/** (Although Xcode could be renamed like Xcode-beta.app so don't check for that specifically)
-    guard !imageName.contains(".simruntime") && !imageName.contains(".app/Contents/Developer") && !imageName.starts(with: "/usr/lib/") && !imageName.starts(with: "/System/Library/") else {
+    guard imageName.starts(with: Bundle.main.bundleURL.path) else {
       continue
     }
 


### PR DESCRIPTION
Rather than checking all these cases, we can just see if the dylib is in the .app

This is also faster because it just uses "starts(with:)" instead of "contains"