### PR TITLE
Add alternative rendering modes on macOS

### DIFF
--- a/Sources/SnapshotPreferences/RenderingModePreference.swift
+++ b/Sources/SnapshotPreferences/RenderingModePreference.swift
@@ -43,7 +43,6 @@ extension View {
     /// ```
     ///
     /// - SeeAlso: `EmergeRenderingMode`
-    @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(visionOS, unavailable)
     @available(tvOS, unavailable)

--- a/Sources/SnapshotPreviewsCore/AppKitRenderingStrategy.swift
+++ b/Sources/SnapshotPreviewsCore/AppKitRenderingStrategy.swift
@@ -47,7 +47,7 @@ public class AppKitRenderingStrategy: RenderingStrategy {
     window.contentViewController = NSViewController()
     window.setContentSize(AppKitContainer.defaultSize)
     window.contentViewController = vc
-    vc.rendered = { [weak window] mode, precision, accessibilityEnabled, appStoreSnapshot in
+    vc.rendered = { [weak window, weak vc] mode, precision, accessibilityEnabled, appStoreSnapshot in
       DispatchQueue.main.async {
         Self.takeSnapshot(mode: mode ?? .nsView, viewController: vc, window: window) { image in
           completion(
@@ -63,12 +63,12 @@ public class AppKitRenderingStrategy: RenderingStrategy {
     }
   }
 
-  private static func takeSnapshot(mode: EmergeRenderingMode, viewController: NSViewController, window: NSWindow?, completion: @escaping (NSImage?) -> Void) {
+  private static func takeSnapshot(mode: EmergeRenderingMode, viewController: NSViewController?, window: NSWindow?, completion: @escaping (NSImage?) -> Void) {
     switch mode {
     case .coreAnimation:
-        completion(viewController.view.layerSnapshot())
+        completion(viewController?.view.layerSnapshot())
     case .nsView:
-      completion(viewController.view.snapshot())
+      completion(viewController?.view.snapshot())
     case .window:
       if let window {
         attemptSnapshot(window: window, maxAttempts: 15, completion: completion)

--- a/Sources/SnapshotSharedModels/RenderingMode.swift
+++ b/Sources/SnapshotSharedModels/RenderingMode.swift
@@ -17,9 +17,15 @@ public enum EmergeRenderingMode: Int {
   case coreAnimation
 
   /// Renders using `UIView.drawHierarchy(in:afterScreenUpdates:true)`.
+  @available(macOS, unavailable)
   case uiView
+    
+  /// Renders using `NSView.bitmapImageRepForCachingDisplay`.
+  @available(iOS, unavailable)
+  case nsView
 
   /// Renders the entire window instead of the previewed view.
-  /// This uses UIWindow.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+  /// This uses `UIWindow.drawHierarchy(in: window.bounds, afterScreenUpdates: true)` on iOS
+  /// This uses `CGWindowListCreateImage` on macOS.
   case window
 }


### PR DESCRIPTION
Enables the `EmergeRenderingMode` on macOS, and adds two new rendering modes on macOS, one based on CALayer.render, and one based on `CGWindowListCreateImage`.

On macOS, it appears that the existing rendering method was not rendering CALayer-based shadows. Even upon isolating a single CALayer and calling it's `render` method, other properties of the CALayer would be rendered properly, but the shadows would not be. The [documentation for CALayer.render](https://developer.apple.com/documentation/quartzcore/calayer/render(in:)) implies that various parts of rendering are not fully implemented on macOS, so given that these shadows appear properly in the actual app, my suspicion is that some other subsystem of macOS handles rendering of these shadows.

The only reliable way I found to render these shadows to an image was to use [CGWindowListCreateImage](https://developer.apple.com/documentation/coregraphics/cgwindowlistcreateimage(_:_:_:_:)). Unfortunately, this method is deprecated, so I'm not sure if it will last forever. But for now, it seems to be the only viable alternative I could find. I considered using ScreenCaptureKit (the suggested alternative to `CGWindowListCreateImage`, but it seemed much more complicated, and required prompting the user for screen recording permissions, which I imagine will create more complexity. So for now, as long as this method is still working, it seems like the preferable approach.

I did find that `CGWindowListCreateImage` would occasionally return nil, and then work again on subsequent requests. It's not completely clear to me why this would happen. So I built in an exponential backoff system to retry up to 15 times before failing. Again, not ideal, but for my use case it seems like the best that I could come up with and is working reliably for me.

I also added support for the CALayer EmergeRenderingMode on macOS, simply because it seemed easy to add and would provide parity with iOS if we're exposing this capability on macOS. But I don't have any actual solid use case for it, and only briefly tested it. So we could also decide to remove that.